### PR TITLE
POC för att få api att funka igen

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -124,7 +124,7 @@ export class Api extends EventEmitter {
     if (this.isFake) return fakeResponse(fake.children())
 
     const hemResponse = await this.fetch('hemPage', routes.hemPage, this.session)
-    const doc = html.parse(decode(await hemResponse.text())) 
+    const doc = html.parse(decode(await hemResponse.text()))
     const xsrfToken = doc.querySelector('input[name="__RequestVerificationToken"]').getAttribute('value') || ''
     if (this.session) {
       this.session.headers = {
@@ -152,16 +152,16 @@ export class Api extends EventEmitter {
     const authResponse = await this.fetch('auth', routes.auth, this.session)
     const auth = await authResponse.text()
 
+    await this.clearCookies()
     const createItemResponse = await this.fetch('createItem', cdn, {
       method: 'POST',
-
       headers: {
         Accept: 'text/plain',
         'Access-Control-Allow-Origin': '*',
         'Content-Type': 'text/plain',
-        'Cookie': this.getSessionCookie(),
         Host: cdnHost,
-        Origin: 'https://etjanst.stockholm.se'
+        Origin: 'https://etjanst.stockholm.se',
+        Connection: 'keep-alive',
       },
       body: auth,
     })


### PR DESCRIPTION
Senaste (briljanta) sättet de stoppar oss är:
Anropet till CreateItem ger 403 om
- Man skickar med någon cookie
- Man har 'Connection: close' som header (!)

Varför POC?
Det här med cookies funkar ju annorlunda mellan node-fetch och react-native fetch.
Vi vill alltså skicka med cookies i alla requests UTOM just CreateItem. I node kan man lösa det genom att skicka in två olika fetch med olika cookieJars. Men i react-native fetch verkar det inte funka så.

Det jag gör här är "the nuclear option" och rensar alla cookies innan anropet.

Allmänt är cookie hanteringen inte 100% som det är nu. Då vi använder fetch-cookie/node-fetch samt react-native fetch så hanteras alla cookies som i en webbläsare. Alla cookies som skickas från servern lagras och skickas vidare i alla requests.
Men vi hanterar också session-cookien själva. Den sätts i session och skickas med i alla requests.
Resultatet blir att vi skickat två session-cookies i alla requests.