### PR TITLE
Fix/working in react native

### DIFF
--- a/credentials-fetch-wrapper.js
+++ b/credentials-fetch-wrapper.js
@@ -1,0 +1,21 @@
+module.exports = function credentialsDecorator (fetch) {
+  fetch = fetch || window.fetch
+
+  async function fetchWrapper (url, opts) {
+    opts = opts || {}
+
+    // Prepare request
+    if(opts.credentials == 'omit'){
+        if(opts.headers && opts.headers.cookie){
+            delete opts.headers.cookie
+        }
+    }
+
+    // Actual request
+    const res = await fetch(url, opts)
+
+    return res
+  }
+
+  return fetchWrapper
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -173,7 +173,7 @@ export class Api extends EventEmitter {
     // Delete cookies from session and empty cookie manager
     delete session.headers.cookie
     const cookies = await this.cookieManager.getCookies(url)
-    this.cookieManager.clearAll()
+    await this.cookieManager.clearAll()
 
     // Perform request
     const response = await this.fetch('createItem', url, session)

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -150,7 +150,8 @@ export class Api extends EventEmitter {
   }
 
   async retrieveAuthToken(url: string, authBody: string): Promise<string> {
-    const cdnHost = new URL(url).host
+    // Unfortunately we can't use new Url(url).host in React-native. It is not implemented.
+    const cdnHost = Api.getTheHostNameFromUrl(url)
     const session = await this.getSession(url, {
       method: 'POST',
       headers: {
@@ -182,6 +183,19 @@ export class Api extends EventEmitter {
 
     const authData = await response.json()
     return authData.token
+  }
+
+  private static getTheHostNameFromUrl(websiteURL : string) {
+    let hostname
+    if (websiteURL.indexOf('//') > -1) {
+      [, , hostname] = websiteURL.split('/')
+    } else {
+      [hostname] = websiteURL.split('/')
+    }
+
+    [hostname] = hostname.split(':');
+    [hostname] = hostname.split('?')
+    return hostname
   }
 
   async fakeMode(): Promise<LoginStatusChecker> {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -54,13 +54,12 @@ export class Api extends EventEmitter {
   }
 
   async getSession(url: string, options: RequestInit = {}): Promise<RequestInit> {
-    const cookie = await this.cookieManager.getCookieString(url)
     return {
       ...options,
       headers: {
         ...this.headers,
         ...options.headers,
-        cookie,
+        cookie: '',
       },
     }
   }
@@ -168,20 +167,11 @@ export class Api extends EventEmitter {
         Connection: 'keep-alive',
       },
       body: authBody,
+      credentials: 'omit',
     })
-
-    // Delete cookies from session and empty cookie manager
-    delete session.headers.cookie
-    const cookies = await this.cookieManager.getCookies(url)
-    await this.cookieManager.clearAll()
 
     // Perform request
     const response = await this.fetch('createItem', url, session)
-
-    // Refill cookie manager
-    cookies.forEach((cookie) => {
-      this.cookieManager.setCookie(cookie, url)
-    })
 
     if (!response.ok) {
       throw new Error(`Server Error [${response.status}] [${response.statusText}] [${url}]`)

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -115,8 +115,14 @@ export class Api extends EventEmitter {
     const session = await this.getSession(url)
     const response = await this.fetch('hemPage', url, session)
     const text = await response.text()
-    const doc = html.parse(decode(text))
-    const xsrfToken = doc.querySelector('input[name="__RequestVerificationToken"]').getAttribute('value') || ''
+
+    const doc = html.parse(decode(text || ''))
+    const htmlInput = doc.querySelector('input[name="__RequestVerificationToken"]')
+    if (htmlInput === null) {
+      // throw new Error('Could not find XSRF-token input field on page')
+      return
+    }
+    const xsrfToken = htmlInput.getAttribute('value') || ''
     this.addHeader('X-XSRF-Token', xsrfToken)
   }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -21,6 +21,7 @@ export interface RequestInit {
   headers?: any
   method?: string
   body?: string
+  credentials?: string
 }
 
 export interface Headers {

--- a/run.js
+++ b/run.js
@@ -16,6 +16,7 @@ const { DateTime } = require('luxon')
 const nodeFetch = require('node-fetch')
 const { CookieJar } = require('tough-cookie')
 const fetchCookie = require('fetch-cookie/node-fetch')
+const credentialsFetchWrapper = require('./credentials-fetch-wrapper')
 const { writeFile } = require('fs/promises')
 const path = require('path')
 const fs = require('fs')
@@ -73,7 +74,8 @@ const record = async (info, data) => {
 
 async function run() {
   const cookieJar = new CookieJar()
-  const fetch = fetchCookie(nodeFetch, cookieJar)
+  const credentialsFetch = credentialsFetchWrapper(nodeFetch)
+  const fetch = fetchCookie(credentialsFetch, cookieJar)
 
   try {
 
@@ -107,9 +109,15 @@ async function run() {
       const classmates = await api.getClassmates(children[0])
       console.log(classmates)
 
+      // Remote schedule api is unstable
       console.log('schedule')
-      const schedule = await api.getSchedule(children[0], DateTime.local(), DateTime.local().plus({ week: 1 }))
-      console.log(schedule)
+      try {
+        const schedule = await api.getSchedule(children[0], DateTime.local(), DateTime.local().plus({ week: 1 }))
+        console.log(schedule)
+      } catch (error) {
+        console.log('Schedule threw error =>', error)
+      }
+     
 
       console.log('news')
       const news = await api.getNews(children[0])

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "declaration": true,
     "outDir": "./dist",
     "strict": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "sourceMap": true
   },
   "include": [
     "lib"


### PR DESCRIPTION
Många små fixar och en större:
- React-native har inte stöd för new Url(url).host - (se första comitten)

Den större:
Vi dubbelhanterade session-cookien. Den hanteras av cookieJar och av oss själva. Det här gjorde att vi skickade två sessioncookies i headern och det externa api:t kastade ibland fel.

Istället för att ta bort alla cookies och lägga tillbaka dem så föreslår jag att vi använder fetch-standarden:
credentials: 'omit' som ska göra så inga cookies skickas med.
Den verkar stödjas av RN men inte av Node impl fetch-cookie.
Jag gjorde en enkel wrapper för att stödja Node - i RN funkar det både i simulatorn och på min iPhone.

Det här gör att vi helt litar på att cookies hanteras av RN. Jag har läst på nätet att folk har haft problem med detta (tex https://build.affinity.co/persisting-sessions-with-react-native-4c46af3bfd83?gi=5f343a4c621d)
Men för mig funkar det när jag testar.