### PR TITLE
fix: 🐛 Fixar senaste blocken

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -170,6 +170,7 @@ export class Api extends EventEmitter {
       },
       body: authBody,
     })
+    delete session.headers['API-Key']
 
     // Temporarily remove cookies
     const cookies = await this.cookieManager.getCookies(url)

--- a/lib/fetcher.ts
+++ b/lib/fetcher.ts
@@ -51,7 +51,7 @@ export default function wrap(fetch: Fetch, options: FetcherOptions = {}): Fetche
       headers: {
         ...init.headers,
         // eslint-disable-next-line max-len
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36',
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.82 Safari/537.36',
       },
     })
 


### PR DESCRIPTION
Om `API-Key`-headern finns med i `CreateItem`-anropet får man en 403:a