### PR TITLE
Fixa inloggningsproblem

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -120,7 +120,7 @@ export class Api extends EventEmitter {
     await this.fetch('login-cookie', url)
   }
 
-  private async retrieveXsrfToken(): Promise<void>{
+  private async retrieveXsrfToken(): Promise<void> {
     const url = routes.childControllerBundle
     const session = this.getRequestInit()
     const response = await this.fetch('XsrfBundle', url, session)
@@ -169,7 +169,6 @@ export class Api extends EventEmitter {
         Origin: 'https://etjanst.stockholm.se',
         Referer: 'https://etjanst.stockholm.se/',
         Connection: 'keep-alive',
-  //      'x-xsrf-token': 'gS6KG0uPHU_5SmGfeuPbFdrhmkA_PtLX7SJNmrSl2gY3RyqgnuvJMlkySJGiNdGGhl3Sc5_H0gLIw9lXmrnB5QeSxJkKdjM0bdI5S27wKkInKKQWjmZRMSGV3rlH3ah9'
       },
       body: authBody,
     })

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -120,18 +120,20 @@ export class Api extends EventEmitter {
     await this.fetch('login-cookie', url)
   }
 
-  private async retrieveXsrfToken(): Promise<void> {
-    const url = routes.hemPage
+  private async retrieveXsrfToken(): Promise<void>{
+    const url = routes.childControllerBundle
     const session = this.getRequestInit()
-    const response = await this.fetch('hemPage', url, session)
+    const response = await this.fetch('XsrfBundle', url, session)
     const text = await response.text()
-    const doc = html.parse(decode(text))
-    const xsrfToken = doc.querySelector('input[name="__RequestVerificationToken"]').getAttribute('value') || ''
-    this.addHeader('X-XSRF-Token', xsrfToken)
+    const xsrfTokenRegex = /'x-xsrf-token':'([\w\d_-]+)'/gm
+    const xsrfTokenMatches = xsrfTokenRegex.exec(text)
+    const xsrfToken = xsrfTokenMatches && xsrfTokenMatches.length > 1 ? xsrfTokenMatches[1] : ''
+
+    this.addHeader('x-xsrf-token', xsrfToken)
   }
 
   private async retrieveApiKey(): Promise<void> {
-    const url = routes.startBundle
+    const url = routes.childControllerBundle
     const session = this.getRequestInit()
     const response = await this.fetch('startBundle', url, session)
     const text = await response.text()

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -48,6 +48,6 @@ export const cdn = 'https://etjanst.stockholm.se/vardnadshavare/base/cdn'
 
 export const auth = 'https://etjanst.stockholm.se/vardnadshavare/base/auth'
 
-export const startBundle = 'https://etjanst.stockholm.se/vardnadshavare/bundles/start'
+export const childControllerBundle = 'https://etjanst.stockholm.se/vardnadshavare/bundles/childcontroller'
 
 export const hemPage = 'https://etjanst.stockholm.se/vardnadshavare/inloggad2/hem'


### PR DESCRIPTION
Det går återigen att logga in (och hämta listan med barn)
* xsrf token hämtas nu med regexp från en ny bundle som heter childcontroller (detta kan ha som sidoeffekt att inloggningen i Android kan börja fungera, men har inte testat)
* Även API nyckel hämtas från samma bundle
* Eventuellt kan bibliotek som har att göra med html-parsning tas bort, eftersom xsrf token inte längre använder sig av dem, men jag har inte kollat om det inte är något annat som behöver dem.

Det verkar vara olika xsrf tokens som finns i html-sidorna och i bundle och den från html-sidorna fungerade inte. Den kanske kommer behövas nån annan gång, så bra att ha det i bakhuvudet att de är olika.