### PR TITLE
Feat/support school menu in different formats

### DIFF
--- a/lib/api.test.ts
+++ b/lib/api.test.ts
@@ -19,6 +19,7 @@ describe('api', () => {
       headers,
     }
     fetch = jest.fn().mockResolvedValue(response)
+    response.text.mockResolvedValue('<html></html>')
     CookieManager.clearAll()
     api = init(fetch, CookieManager)
   })

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -317,11 +317,29 @@ export class Api extends EventEmitter {
   public async getMenu(child: Child): Promise<MenuItem[]> {
     if (this.isFake) return fakeResponse(fake.menu(child))
 
-    const url = routes.menu(child.id)
+    const menuService = await this.getMenuChoice(child)
+    if (menuService === 'rss') {
+      const url = routes.menuRss(child.id)
+      const session = this.getRequestInit()
+      const response = await this.fetch('menu-rss', url, session)
+      const data = await response.json()
+      return parse.menu(data)
+    }
+
+    const url = routes.menuList(child.id)
     const session = this.getRequestInit()
-    const response = await this.fetch('menu', url, session)
+    const response = await this.fetch('menu-list', url, session)
     const data = await response.json()
-    return parse.menu(data)
+    return parse.menuList(data)
+  }
+
+  private async getMenuChoice(child : Child) : Promise<string> {
+    const url = routes.menuChoice(child.id)
+    const session = this.getRequestInit()
+    const response = await this.fetch('menu-choice', url, session)
+    const data = await response.json()
+    const etjanstResponse = parse.etjanst(data)
+    return etjanstResponse
   }
 
   public async getNotifications(child: Child): Promise<Notification[]> {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -128,7 +128,7 @@ export class Api extends EventEmitter {
     const response = await this.fetch('hemPage', url, session)
     const text = await response.text()
     const doc = html.parse(decode(text))
-    const xsrfToken = doc.querySelector('input[name="__RequestVerificationToken"]').getAttribute('value') || ''
+    const xsrfToken = doc.querySelector('input[name="__RequestVerificationToken"]')?.getAttribute('value') || ''
     const scriptTags = doc.querySelectorAll('script')
     const childControllerScriptTag = scriptTags.find((elem) => {
       const srcAttr = elem.getAttribute('src')

--- a/lib/parse.test.ts
+++ b/lib/parse.test.ts
@@ -382,6 +382,71 @@ describe('parse', () => {
         }])
       })
     })
+
+    describe('menu-list', () => {
+      beforeEach(() => {
+        response = {
+          Success: true,
+          Error: null,
+          Data: {
+            "SelectedWeek": 12,
+            "Menus": [
+                {
+                    "Week": "12",
+                    "Mon": "Köttfärslimpa med sås och potatis",
+                    "Tue": "Curryfisk med ris",
+                    "Wed": "Tagliatelle med vegetarisk sås",
+                    "Thu": "Chorizo med stuvad potatis",
+                    "Fri": "Ört och vitlöksinbakad fisk, potatis"
+                },
+                {
+                    "Week": "19",
+                    "Mon": "FISKGRATÄNG WALEWSKA",
+                    "Tue": "STEKT FLÄSK MED RAGGMUNK",
+                    "Wed": "PENNEPASTA MED TONFISK",
+                    "Thu": "KÖTTGRYTA MED POTATIS",
+                    "Fri": "GRÖNSAKSGRATÄNG MED TZATZIKI"
+                },
+                {
+                    "Week": "20",
+                    "Mon": "SPAGHETTI SALMONE ",
+                    "Tue": "STEKT FALUKORV MED SENAPSSÅS OCH POTATIS",
+                    "Wed": "SOPPA MED RISONI OCH HEMBAKAT BRÖD",
+                    "Thu": "PANERAD FISK MED SKAGEN OCH POTATIS",
+                    "Fri": "TACOS"
+                }
+            ]
+          }
+        }
+      })
+      it('parses menu correctly', () => {
+        const result = parse.menuList(response)
+
+        expect(result).toEqual([
+          {
+            title: 'Måndag - Vecka 12',
+            description: 'Köttfärslimpa med sås och potatis'
+          },
+          {
+            title: 'Tisdag - Vecka 12',
+            description: 'Curryfisk med ris'
+          },
+          {
+            title: 'Onsdag - Vecka 12',
+            description: 'Tagliatelle med vegetarisk sås'
+          },
+          {
+            title: 'Torsdag - Vecka 12',
+            description: 'Chorizo med stuvad potatis'
+          },
+          {
+            title: 'Fredag - Vecka 12',
+            description: 'Ört och vitlöksinbakad fisk, potatis'
+          }
+        ])
+      })
+    })
+
     describe('user', () => {
       let userResponse: any
       beforeEach(() => {

--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -1,7 +1,7 @@
 import { DateTime, DateTimeOptions } from 'luxon'
 import { toMarkdown } from './parseHtml'
 import {
-  CalendarItem, Child, Classmate, Guardian, MenuItem, NewsItem, ScheduleItem, User, Notification,
+  CalendarItem, Child, Classmate, Guardian, MenuItem, NewsItem, ScheduleItem, User, Notification, MenuList,
 } from './types'
 
 const camel = require('camelcase-keys')
@@ -127,7 +127,47 @@ export const menuItem = ({
   title,
   description: toMarkdown(description),
 })
+
 export const menu = (data: any): MenuItem[] => etjanst(data).map(menuItem)
+
+export const menuList = (data : any) : MenuItem[] => {
+  const etjanstData = etjanst(data)
+  const menuFS = etjanstData as MenuList
+
+  const currentWeek = menuFS.menus.find((item) => menuFS.selectedWeek === Number.parseInt(item.week, 10))
+
+  if (!currentWeek) {
+    return [{
+      title: 'Måndag - Vecka ?',
+      description: 'Hittade ingen meny',
+    }]
+  }
+
+  const menuItemsFS = [
+    {
+      title: `Måndag - Vecka ${currentWeek.week}`,
+      description: currentWeek.mon,
+    },
+    {
+      title: `Tisdag - Vecka ${currentWeek.week}`,
+      description: currentWeek.tue,
+    },
+    {
+      title: `Onsdag - Vecka ${currentWeek.week}`,
+      description: currentWeek.wed,
+    },
+    {
+      title: `Torsdag - Vecka ${currentWeek.week}`,
+      description: currentWeek.thu,
+    },
+    {
+      title: `Fredag - Vecka ${currentWeek.week}`,
+      description: currentWeek.fri,
+    },
+  ]
+
+  return menuItemsFS
+}
 
 export const notification = ({
   notification: {

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -36,8 +36,16 @@ export const notifications = (childId: string) => (
   `https://etjanst.stockholm.se/vardnadshavare/inloggad2/Overview/GetNotification?childId=${childId}`
 )
 
-export const menu = (childId: string) => (
+export const menuRss = (childId: string) => (
   `https://etjanst.stockholm.se/vardnadshavare/inloggad2/Matsedel/GetMatsedelRSS?childId=${childId}`
+)
+
+export const menuList = (childId: string) => (
+  `https://etjanst.stockholm.se/vardnadshavare/inloggad2/Matsedel/GetMatsedelList?childId=${childId}`
+)
+
+export const menuChoice = (childId: string) => (
+  `https://etjanst.stockholm.se/vardnadshavare/inloggad2/Matsedel/GetMatsedelChoice?childId=${childId}`
 )
 
 export const schedule = (childId: string, fromDate: string, endDate: string) => (

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -156,6 +156,20 @@ export interface MenuItem {
   description: string
 }
 
+export interface MenuList {
+  selectedWeek: number,
+  menus: MenuListItem[]
+}
+
+export interface MenuListItem {
+  'week': string,
+  'mon': string,
+  'tue': string,
+  'wed': string,
+  'thu': string,
+  'fri': string
+}
+
 export interface User {
   personalNumber?: string
   isAuthenticated?: boolean


### PR DESCRIPTION
For some reason there are two separate endpoints for getting the menu (matsedel) for a child, "RSS" or "sharepoint-list".
- First we have to query a third endpoint to know which to use
- Then we have to parse a totally separate data-format to get the menu

Why they have put this logic in the client is beyond me. It is so wrong on so many levels.