### PR TITLE
fix: parse intro without positive lookbehind regex

### DIFF
--- a/lib/parse.test.ts
+++ b/lib/parse.test.ts
@@ -242,7 +242,7 @@ describe('parse', () => {
                 ModDateSE: '18 december 2020 16:18',
                 Source: 'Livets hårda skolklasser',
                 Preamble:
-                  'Hej, Nu är problemet löst! Alla betyg syns som de ska. God jul!...',
+                  'Hej,Nu är problemet löst! Alla betyg syns som de ska.God jul!...',
                 BannerImageUrl: 'A703552D-DBF3-45B0-8E67-6E062105A0C5.jpeg',
                 BannerImageGuid: 'A703552D-DBF3-45B0-8E67-6E062105A0C5',
                 BannerImageListId: 'FFBE49E9-BDE1-4C75-BA0E-D98D4E2FCF21',

--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -150,7 +150,7 @@ export const newsItem = ({
     modified,
     id: newsId,
     author: authorDisplayName,
-    intro: preamble.replace(/(?<=[,.!])(\w)/ig, ' $1'),
+    intro: preamble.replace(/([!,.])(\w)/gi, '$1 $2'),
     imageUrl: bannerImageUrl,
     fullImageUrl: `${IMAGE_HOST}${bannerImageUrl}`,
     imageAltText: altText,


### PR DESCRIPTION
This solves the issue in #99 but without positive lookbehind because it doesn't work in React Native