### PR TITLE
fix: use date constructor instead of luxon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 14
+      - name: Setup timezone
+        uses: zcong1993/setup-timezone@master
+        with:
+          timezone: Europe/Stockholm
       - name: Install dependencies
         run: yarn install --immutable --silent --non-interactive 2> >(grep -v warning 1>&2)
       - name: Audit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,12 @@ jobs:
         uses: actions/setup-node@v2.1.2
         with:
           node-version: 14.x
+
+      - name: Setup timezone
+        uses: zcong1993/setup-timezone@master
+        with:
+          timezone: Europe/Stockholm
+
       - run: yarn install --immutable --silent --non-interactive 2> >(grep -v warning 1>&2)
       - run: yarn audit
       - run: yarn lint

--- a/lib/fakeData.ts
+++ b/lib/fakeData.ts
@@ -242,8 +242,8 @@ const data: any = {
         fullImageUrl:
           'https://cdn.breakit.se/assets/article/6607f9b923edb6f85aa4417bab43c0f8.jpg?d=980x500',
         imageAltText: 'Nyhetsbild. Bildtext ej tillgänglig.',
-        published: '2020-08-16T21:10:00.000+02:0',
-        modified: '2021-01-22T14:49:00.000+01:00',
+        published: '2020-08-16T21:10:00.000Z',
+        modified: '2021-01-22T14:49:00.000Z',
       },
       {
         id: 'asdfabbuasdfs',
@@ -256,8 +256,8 @@ const data: any = {
         fullImageUrl:
           'https://live.staticflickr.com/4063/4369776892_5cd42d27ba.jpg',
         imageAltText: 'Nyhetsbild. Bildtext ej tillgänglig.',
-        published: '2020-10-13T09:10:00.000+02:00',
-        modified: '2021-02-09T15:45:00.000+02:00',
+        published: '2020-10-13T09:10:00.000Z',
+        modified: '2021-02-09T15:45:00.000Z',
       },
       {
         id: 'asdfasdfasdfs',
@@ -270,8 +270,8 @@ const data: any = {
         fullImageUrl:
           'https://www.mitti.se/_internal/cimg!0/ejf8efxee735ymm8tm40q3hhkl36sdt.jpeg',
         imageAltText: 'Nyhetsbild. Bildtext ej tillgänglig.',
-        published: '2020-08-16T21:10:00.000+02:0',
-        modified: '2021-01-22T14:49:00.000+01:00',
+        published: '2020-08-16T21:10:00.000Z',
+        modified: '2021-01-22T14:49:00.000Z',
       },
     ],
     calendar: [
@@ -769,8 +769,8 @@ const data: any = {
         fullImageUrl:
           'https://timbro.se/app/uploads/2020/10/broman-skolplattformen-1280x752.jpg',
         imageAltText: 'Nyhetsbild. Bildtext ej tillgänglig.',
-        published: '2020-08-16T21:10:00.000+02:0',
-        modified: '2021-01-22T14:49:00.000+01:00',
+        published: '2020-08-16T21:10:00.000Z',
+        modified: '2021-01-22T14:49:00.000Z',
       },
       {
         id: 'asdfabbuasdfs',
@@ -783,8 +783,8 @@ const data: any = {
         fullImageUrl:
           'https://live.staticflickr.com/4063/4369776892_5cd42d27ba.jpg',
         imageAltText: 'Nyhetsbild. Bildtext ej tillgänglig.',
-        published: '2020-10-13T09:10:00.000+02:00',
-        modified: '2021-02-09T15:45:00.000+02:00',
+        published: '2020-10-13T09:10:00.000Z',
+        modified: '2021-02-09T15:45:00.000Z',
       },
       {
         id: 'asdfasdfasdfs',
@@ -797,8 +797,8 @@ const data: any = {
         fullImageUrl:
           'https://www.mitti.se/_internal/cimg!0/ejf8efxee735ymm8tm40q3hhkl36sdt.jpeg',
         imageAltText: 'Nyhetsbild. Bildtext ej tillgänglig.',
-        published: '2020-08-16T21:10:00.000+02:0',
-        modified: '2021-01-22T14:49:00.000+01:00',
+        published: '2020-08-16T21:10:00.000Z',
+        modified: '2021-01-22T14:49:00.000Z',
       },
       {
         id: 'asdfasdfasdfd',
@@ -811,8 +811,8 @@ const data: any = {
         imageUrl: '6607f9b923edb6f85aa4417bab43c0f8.jpg',
         fullImageUrl: 'https://unsplash.com/photos/yB_aiAWkm40',
         imageAltText: 'Nyhetsbild. Bildtext ej tillgänglig.',
-        published: '2020-08-16T21:10:00.000+02:0',
-        modified: '2021-01-22T14:49:00.000+01:00',
+        published: '2020-08-16T21:10:00.000Z',
+        modified: '2021-01-22T14:49:00.000Z',
       },
       {
         id: 'asdfasdfasdfdsa',
@@ -824,8 +824,8 @@ const data: any = {
         imageUrl: '6607f9b923edb6f85aa4417bab43c0f8.jpg',
         fullImageUrl: 'https://unsplash.com/photos/7K17MvT8qBg',
         imageAltText: 'Nyhetsbild. Bildtext ej tillgänglig.',
-        published: '2021-01-16T21:10:03.000+02:0',
-        modified: '2021-01-17T14:40:00.000+01:00',
+        published: '2021-01-16T21:10:03.000Z',
+        modified: '2021-01-17T14:40:00.000Z',
       },
       {
         id: 'asdfasdfasdfbvdsa',
@@ -838,8 +838,8 @@ const data: any = {
         imageUrl: '6607f9b923edb6f85aa4417bab43c0f8.jpg',
         fullImageUrl: 'https://unsplash.com/photos/SkbEZ16VywM',
         imageAltText: 'Nyhetsbild. Bildtext ej tillgänglig.',
-        published: '2021-02-02T14:10:03.000+02:0',
-        modified: '2021-02-02T14:15:00.000+01:00',
+        published: '2021-02-02T14:10:03.000Z',
+        modified: '2021-02-02T14:15:00.000Z',
       },
     ],
     calendar: [

--- a/lib/parse.test.ts
+++ b/lib/parse.test.ts
@@ -132,8 +132,8 @@ describe('parse', () => {
       it('parses start and end date without time', () => {
         const [, secondEvent] = parse.calendar(response)
 
-        expect(secondEvent.startDate).toEqual('2021-05-27T22:00:00.000Z')
-        expect(secondEvent.endDate).toEqual('2021-05-27T22:00:00.000Z')
+        expect(secondEvent.startDate).toEqual('2021-05-28T00:00:00.000Z')
+        expect(secondEvent.endDate).toEqual('2021-05-28T00:00:00.000Z')
       })
     })
 
@@ -240,8 +240,8 @@ describe('parse', () => {
             title: 'Canceled: Julavslutning 8C',
             description: 'Nåt kul',
             location: 'Lakritskolan',
-            startDate: '2020-12-14T14:10:00.000+01:00',
-            endDate: '2020-12-14T14:40:00.000+01:00',
+            startDate: '2020-12-14T13:10:00.000Z',
+            endDate: '2020-12-14T13:40:00.000Z',
             oneDayEvent: true,
             allDayEvent: false,
           },
@@ -327,8 +327,8 @@ describe('parse', () => {
         expect(item.intro).toEqual(
           'Hej, Nu är problemet löst! Alla betyg syns som de ska. God jul!...'
         )
-        expect(item.modified).toEqual('2020-12-18T16:18:00.000+01:00')
-        expect(item.published).toEqual('2020-12-18T16:15:00.000+01:00')
+        expect(item.modified).toEqual('2020-12-18T15:18:00.000Z')
+        expect(item.published).toEqual('2020-12-18T15:15:00.000Z')
       })
       it('parses body correctly', () => {
         const [item] = parse.news(response)
@@ -408,8 +408,8 @@ describe('parse', () => {
         expect(item.intro).toEqual(
           'Kära vårdnadshavare! I helgen är det avlusningsdagar!'
         )
-        expect(item.published).toEqual('2021-02-04T14:31:00.000+01:00')
-        expect(item.modified).toEqual('2021-02-14T14:37:00.000+01:00')
+        expect(item.published).toEqual('2021-02-04T13:31:00.000Z')
+        expect(item.modified).toEqual('2021-02-14T13:37:00.000Z')
         expect(item.author).toEqual('Tieto Evry')
       })
       it('parses body correctly', () => {
@@ -586,7 +586,7 @@ describe('parse', () => {
             message: 'Betygen är publicerade.',
             sender: 'Elevdokumentation',
             url: 'https://elevdokumentation.stockholm.se/loa3/gradesStudent.do',
-            dateCreated: '2020-12-18T15:59:46.340+01:00',
+            dateCreated: '2020-12-18T14:59:46.340Z',
             category: null,
             type: 'webnotify',
           },

--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -1,4 +1,3 @@
-import { DateTime, DateTimeOptions } from 'luxon'
 import { toMarkdown } from './parseHtml'
 import {
   CalendarItem,
@@ -14,24 +13,6 @@ import {
 } from './types'
 
 const camel = require('camelcase-keys')
-
-const dateTimeOptions: DateTimeOptions = {
-  locale: 'sv',
-  setZone: true,
-  zone: 'Europe/Stockholm',
-}
-
-const tryParseDate = (
-  date: string,
-  format: string,
-  options: DateTimeOptions
-) => {
-  try {
-    return DateTime.fromFormat(date, format, options).toISO()
-  } catch (err) {
-    return ''
-  }
-}
 
 export interface EtjanstResponse {
   Success: boolean
@@ -116,10 +97,10 @@ export const calendarItem = ({
   location,
   allDay: allDayEvent,
   startDate: longEventDateTime
-    ? DateTime.fromSQL(longEventDateTime, dateTimeOptions).toUTC().toISO()
+    ? new Date(longEventDateTime).toISOString()
     : undefined,
   endDate: longEndDateTime
-    ? DateTime.fromSQL(longEndDateTime, dateTimeOptions).toUTC().toISO()
+    ? new Date(longEndDateTime).toISOString()
     : undefined,
 })
 export const calendar = (data: any): CalendarItem[] =>
@@ -137,26 +118,18 @@ export const newsItem = ({
   modDateSe,
   authorDisplayName,
   altText,
-}: any): NewsItem => {
-  const published = tryParseDate(
-    pubDateSe,
-    'd LLLL yyyy HH:mm',
-    dateTimeOptions
-  )
-  const modified = tryParseDate(modDateSe, 'd LLLL yyyy HH:mm', dateTimeOptions)
-  return {
-    header,
-    published,
-    modified,
-    id: newsId,
-    author: authorDisplayName,
-    intro: preamble.replace(/([!,.])(\w)/gi, '$1 $2'),
-    imageUrl: bannerImageUrl,
-    fullImageUrl: `${IMAGE_HOST}${bannerImageUrl}`,
-    imageAltText: altText,
-    body: toMarkdown(body),
-  }
-}
+}: any): NewsItem => ({
+  header,
+  published: pubDateSe ? new Date(pubDateSe).toISOString() : '',
+  modified: modDateSe ? new Date(modDateSe).toISOString() : '',
+  id: newsId,
+  author: authorDisplayName,
+  intro: preamble.replace(/([!,.])(\w)/gi, '$1 $2'),
+  imageUrl: bannerImageUrl,
+  fullImageUrl: `${IMAGE_HOST}${bannerImageUrl}`,
+  imageAltText: altText,
+  body: toMarkdown(body),
+})
 export const news = (data: any): NewsItem[] =>
   etjanst(data).newsItems.map(newsItem)
 
@@ -176,8 +149,8 @@ export const scheduleItem = ({
   description,
   location,
   allDayEvent,
-  startDate: DateTime.fromSQL(longEventDateTime, dateTimeOptions).toISO(),
-  endDate: DateTime.fromSQL(longEndDateTime, dateTimeOptions).toISO(),
+  startDate: new Date(longEventDateTime).toISOString(),
+  endDate: new Date(longEndDateTime).toISOString(),
   oneDayEvent: isSameDay,
 })
 export const schedule = (data: any): ScheduleItem[] =>
@@ -251,7 +224,7 @@ export const notification = ({
   message: messagetext,
   sender: name,
   url: linkbackurl,
-  dateCreated: DateTime.fromISO(dateCreated, dateTimeOptions).toISO(),
+  dateCreated: new Date(dateCreated).toISOString(),
   category,
   type,
 })


### PR DESCRIPTION
`new Date` seems to work perfectly fine for date parsing instead of using `luxon` and we get a properly formatted ISO string.

Also, fix dates in `fakeData`.