### PR TITLE
fix: add date handler

### DIFF
--- a/lib/parse.test.ts
+++ b/lib/parse.test.ts
@@ -132,8 +132,8 @@ describe('parse', () => {
       it('parses start and end date without time', () => {
         const [, secondEvent] = parse.calendar(response)
 
-        expect(secondEvent.startDate).toEqual('2021-05-28T00:00:00.000Z')
-        expect(secondEvent.endDate).toEqual('2021-05-28T00:00:00.000Z')
+        expect(secondEvent.startDate).toEqual('2021-05-27T22:00:00.000Z')
+        expect(secondEvent.endDate).toEqual('2021-05-27T22:00:00.000Z')
       })
     })
 

--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -1,3 +1,4 @@
+import { parseDate } from './utils/dateHandling'
 import { toMarkdown } from './parseHtml'
 import {
   CalendarItem,
@@ -96,12 +97,8 @@ export const calendarItem = ({
   description,
   location,
   allDay: allDayEvent,
-  startDate: longEventDateTime
-    ? new Date(longEventDateTime).toISOString()
-    : undefined,
-  endDate: longEndDateTime
-    ? new Date(longEndDateTime).toISOString()
-    : undefined,
+  startDate: parseDate(longEventDateTime),
+  endDate: parseDate(longEndDateTime),
 })
 export const calendar = (data: any): CalendarItem[] =>
   etjanst(data).map(calendarItem)
@@ -149,8 +146,8 @@ export const scheduleItem = ({
   description,
   location,
   allDayEvent,
-  startDate: new Date(longEventDateTime).toISOString(),
-  endDate: new Date(longEndDateTime).toISOString(),
+  startDate: parseDate(longEventDateTime),
+  endDate: parseDate(longEndDateTime),
   oneDayEvent: isSameDay,
 })
 export const schedule = (data: any): ScheduleItem[] =>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -148,8 +148,8 @@ export interface ScheduleItem {
   title: string
   description?: string
   location?: string
-  startDate: string
-  endDate: string
+  startDate?: string
+  endDate?: string
   oneDayEvent: boolean
   allDayEvent: boolean
 }

--- a/lib/utils/__tests__/dateHandling.test.ts
+++ b/lib/utils/__tests__/dateHandling.test.ts
@@ -1,0 +1,11 @@
+import { parseDate } from '../dateHandling'
+
+test.each([
+  ['2020-12-21 09:00', '2020-12-21T08:00:00.000Z'],
+  ['2021-05-28', '2021-05-27T22:00:00.000Z'],
+  ['2 oktober 2020', '2020-10-01T22:00:00.000Z'],
+  ['12 oktober 2020', '2020-10-11T22:00:00.000Z'],
+  ['This is an invalid date', undefined],
+])('handles date parsing of %s', (input, expected) => {
+  expect(parseDate(input)).toEqual(expected)
+})

--- a/lib/utils/dateHandling.ts
+++ b/lib/utils/dateHandling.ts
@@ -1,0 +1,41 @@
+import { DateTime } from 'luxon'
+
+const options = {
+  locale: 'sv',
+}
+
+export const parseDate = (input?: string): string | undefined => {
+  if (!input) {
+    return undefined
+  }
+
+  const dateParse = (format: string) =>
+    DateTime.fromFormat(input, format, options)
+
+  const dateAndTime = dateParse('yyyy-MM-dd HH:mm')
+
+  if (dateAndTime.isValid) {
+    return dateAndTime.toUTC().toISO()
+  }
+
+  const onlyDate = dateParse('yyyy-MM-dd')
+
+  if (onlyDate.isValid) {
+    return onlyDate.toUTC().toISO()
+  }
+
+  const dateLongForm = dateParse('dd MMMM yyyy')
+
+  if (dateLongForm.isValid) {
+    return dateLongForm.toUTC().toISO()
+  }
+
+  const dateLongFormOneDigit = dateParse('d MMMM yyyy')
+
+  if (dateLongFormOneDigit.isValid) {
+    return dateLongFormOneDigit.toUTC().toISO()
+  }
+
+  // Explicit return to satisfy ESLint
+  return undefined
+}


### PR DESCRIPTION
No date library seems to handle all the cases we have. To fix this we can use `DateTime.fromFormat` and explicitly add the formats we expect. It's not the most beautiful, but it works and it's easy to add any new cases.

This PR introduces breaking changes to the types where `startDate` and `endDate` in `ScheduleItem` can potentially be `undefined`