### PR TITLE
fix: handle long dates with time and iso

### DIFF
--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -117,8 +117,8 @@ export const newsItem = ({
   altText,
 }: any): NewsItem => ({
   header,
-  published: pubDateSe ? new Date(pubDateSe).toISOString() : '',
-  modified: modDateSe ? new Date(modDateSe).toISOString() : '',
+  published: parseDate(pubDateSe) || '',
+  modified: parseDate(modDateSe) || '',
   id: newsId,
   author: authorDisplayName,
   intro: preamble.replace(/([!,.])(\w)/gi, '$1 $2'),
@@ -221,7 +221,7 @@ export const notification = ({
   message: messagetext,
   sender: name,
   url: linkbackurl,
-  dateCreated: new Date(dateCreated).toISOString(),
+  dateCreated: parseDate(dateCreated) || '',
   category,
   type,
 })

--- a/lib/utils/__tests__/dateHandling.test.ts
+++ b/lib/utils/__tests__/dateHandling.test.ts
@@ -5,6 +5,8 @@ test.each([
   ['2021-05-28', '2021-05-27T22:00:00.000Z'],
   ['2 oktober 2020', '2020-10-01T22:00:00.000Z'],
   ['12 oktober 2020', '2020-10-11T22:00:00.000Z'],
+  ['5 oktober 2020 11:34', '2020-10-05T09:34:00.000Z'],
+  ['15 oktober 2020 11:34', '2020-10-15T09:34:00.000Z'],
   ['This is an invalid date', undefined],
 ])('handles date parsing of %s', (input, expected) => {
   expect(parseDate(input)).toEqual(expected)

--- a/lib/utils/__tests__/dateHandling.test.ts
+++ b/lib/utils/__tests__/dateHandling.test.ts
@@ -7,6 +7,8 @@ test.each([
   ['12 oktober 2020', '2020-10-11T22:00:00.000Z'],
   ['5 oktober 2020 11:34', '2020-10-05T09:34:00.000Z'],
   ['15 oktober 2020 11:34', '2020-10-15T09:34:00.000Z'],
+  ['2020-12-18T15:59:46.34', '2020-12-18T14:59:46.340Z'],
+  ['2020-12-18T15:59:46.340Z', '2020-12-18T15:59:46.340Z'],
   ['This is an invalid date', undefined],
 ])('handles date parsing of %s', (input, expected) => {
   expect(parseDate(input)).toEqual(expected)

--- a/lib/utils/dateHandling.ts
+++ b/lib/utils/dateHandling.ts
@@ -4,6 +4,8 @@ const options = {
   locale: 'sv',
 }
 
+const toISOString = (date: DateTime) => date.toUTC().toISO()
+
 export const parseDate = (input?: string): string | undefined => {
   if (!input) {
     return undefined
@@ -12,28 +14,34 @@ export const parseDate = (input?: string): string | undefined => {
   const dateParse = (format: string) =>
     DateTime.fromFormat(input, format, options)
 
+  const dateISO = DateTime.fromISO(input)
+
+  if (dateISO.isValid) {
+    return toISOString(dateISO)
+  }
+
   const dateAndTime = dateParse('yyyy-MM-dd HH:mm')
 
   if (dateAndTime.isValid) {
-    return dateAndTime.toUTC().toISO()
+    return toISOString(dateAndTime)
   }
 
   const onlyDate = dateParse('yyyy-MM-dd')
 
   if (onlyDate.isValid) {
-    return onlyDate.toUTC().toISO()
+    return toISOString(onlyDate)
   }
 
   const dateLongForm = dateParse('d MMMM yyyy')
 
   if (dateLongForm.isValid) {
-    return dateLongForm.toUTC().toISO()
+    return toISOString(dateLongForm)
   }
 
   const dateTimeLongForm = dateParse('d MMMM yyyy HH:mm')
 
   if (dateTimeLongForm.isValid) {
-    return dateTimeLongForm.toUTC().toISO()
+    return toISOString(dateTimeLongForm)
   }
 
   // Explicit return to satisfy ESLint

--- a/lib/utils/dateHandling.ts
+++ b/lib/utils/dateHandling.ts
@@ -24,16 +24,16 @@ export const parseDate = (input?: string): string | undefined => {
     return onlyDate.toUTC().toISO()
   }
 
-  const dateLongForm = dateParse('dd MMMM yyyy')
+  const dateLongForm = dateParse('d MMMM yyyy')
 
   if (dateLongForm.isValid) {
     return dateLongForm.toUTC().toISO()
   }
 
-  const dateLongFormOneDigit = dateParse('d MMMM yyyy')
+  const dateTimeLongForm = dateParse('d MMMM yyyy HH:mm')
 
-  if (dateLongFormOneDigit.isValid) {
-    return dateLongFormOneDigit.toUTC().toISO()
+  if (dateTimeLongForm.isValid) {
+    return dateTimeLongForm.toUTC().toISO()
   }
 
   // Explicit return to satisfy ESLint


### PR DESCRIPTION
This PR fixes dates on the form `2 oktober 2020 11:30` as well as properly formatted ISO strings. All date handling that used `new Date` is now using `parseDate`