### PR TITLE
feat: 🎸 Remove required personal number in route

### DIFF
--- a/lib/__tests__/__snapshots__/routes.test.ts.snap
+++ b/lib/__tests__/__snapshots__/routes.test.ts.snap
@@ -6,9 +6,11 @@ exports[`handles route children 1`] = `"https://etjanst.stockholm.se/vardnadshav
 
 exports[`handles route classmates 1`] = `"https://etjanst.stockholm.se/vardnadshavare/inloggad2/contacts/GetStudentsByClass?studentId=123"`;
 
-exports[`handles route classmates 2`] = `"https://etjanst.stockholm.se/vardnadshavare/base/getuserdata"`;
-
 exports[`handles route image 1`] = `"https://etjanst.stockholm.se/vardnadshavare/inloggad2/NewsBanner?url=https://example.com/img.png"`;
+
+exports[`handles route login with personal number 1`] = `"https://login003.stockholm.se/NECSadcmbid/authenticate/NECSadcmbid?TARGET=-SM-HTTPS%3a%2f%2flogin001%2estockholm%2ese%2fNECSadc%2fmbid%2fb64startpage%2ejsp%3fstartpage%3daHR0cHM6Ly9ldGphbnN0LnN0b2NraG9sbS5zZS92YXJkbmFkc2hhdmFyZS9pbmxvZ2dhZDIvaGVt&initialize=bankid&personalNumber=201701012393&_=1618404258782"`;
+
+exports[`handles route login without personal number 1`] = `"https://login003.stockholm.se/NECSadcmbid/authenticate/NECSadcmbid?TARGET=-SM-HTTPS%3a%2f%2flogin001%2estockholm%2ese%2fNECSadc%2fmbid%2fb64startpage%2ejsp%3fstartpage%3daHR0cHM6Ly9ldGphbnN0LnN0b2NraG9sbS5zZS92YXJkbmFkc2hhdmFyZS9pbmxvZ2dhZDIvaGVt&initialize=bankid&_=1618404258782"`;
 
 exports[`handles route menuChoice 1`] = `"https://etjanst.stockholm.se/vardnadshavare/inloggad2/Matsedel/GetMatsedelChoice?childId=123"`;
 
@@ -23,3 +25,5 @@ exports[`handles route newsDetails 1`] = `"https://etjanst.stockholm.se/vardnads
 exports[`handles route notifications 1`] = `"https://etjanst.stockholm.se/vardnadshavare/inloggad2/Overview/GetNotification?childId=123"`;
 
 exports[`handles route schedule 1`] = `"https://etjanst.stockholm.se/vardnadshavare/inloggad2/Calender/GetSchema?childId=123&startDate=2021-01-01&endDate=2021-01-01"`;
+
+exports[`handles route user 1`] = `"https://etjanst.stockholm.se/vardnadshavare/base/getuserdata"`;

--- a/lib/__tests__/routes.test.ts
+++ b/lib/__tests__/routes.test.ts
@@ -1,10 +1,12 @@
 import * as routes from '../routes'
 
+Date.now = jest.fn(() => 1618404258782)
+
 test.each([
   ['children', routes.children],
   ['calender', routes.calendar('123')],
   ['classmates', routes.classmates('123')],
-  ['classmates', routes.user],
+  ['user', routes.user],
   ['news', routes.news('123')],
   ['newsDetails', routes.newsDetails('123', '321')],
   ['image', routes.image('https://example.com/img.png')],
@@ -13,6 +15,8 @@ test.each([
   ['menuList', routes.menuList('123')],
   ['menuChoice', routes.menuChoice('123')],
   ['schedule', routes.schedule('123', '2021-01-01', '2021-01-01')],
+  ['login with personal number', routes.login('201701012393')],
+  ['login without personal number', routes.login()],
 ])('handles route %s', (_name, input) => {
   expect(input).toMatchSnapshot()
 })

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -111,8 +111,8 @@ export class Api extends EventEmitter {
     this.headers[name] = value
   }
 
-  public async login(personalNumber: string): Promise<LoginStatusChecker> {
-    if (personalNumber.endsWith('1212121212')) return this.fakeMode()
+  public async login(personalNumber?: string): Promise<LoginStatusChecker> {
+    if (personalNumber !== undefined && personalNumber.endsWith('1212121212')) return this.fakeMode()
 
     this.isFake = false
 

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -1,7 +1,10 @@
-export const login = (personalNumber: string) =>
-  `https://login003.stockholm.se/NECSadcmbid/authenticate/NECSadcmbid?TARGET=-SM-HTTPS%3a%2f%2flogin001%2estockholm%2ese%2fNECSadc%2fmbid%2fb64startpage%2ejsp%3fstartpage%3daHR0cHM6Ly9ldGphbnN0LnN0b2NraG9sbS5zZS92YXJkbmFkc2hhdmFyZS9pbmxvZ2dhZDIvaGVt&initialize=bankid&personalNumber=${personalNumber}&_=${Date.now()}`
+export const login = (personalNumber?: string) => {
+  const baseUrl = 'https://login003.stockholm.se/NECSadcmbid/authenticate/NECSadcmbid?TARGET=-SM-HTTPS%3a%2f%2flogin001%2estockholm%2ese%2fNECSadc%2fmbid%2fb64startpage%2ejsp%3fstartpage%3daHR0cHM6Ly9ldGphbnN0LnN0b2NraG9sbS5zZS92YXJkbmFkc2hhdmFyZS9pbmxvZ2dhZDIvaGVt'
+  const optionalPersonalNumber = personalNumber === undefined ? '' : `&personalNumber=${personalNumber}`
+  return `${baseUrl}&initialize=bankid${optionalPersonalNumber}&_=${Date.now()}`
+}
 
-export const loginStatus = (order: string) =>
+  export const loginStatus = (order: string) =>
   `https://login003.stockholm.se/NECSadcmbid/authenticate/NECSadcmbid?TARGET=-SM-HTTPS%3a%2f%2flogin001%2estockholm%2ese%2fNECSadc%2fmbid%2fb64startpage%2ejsp%3fstartpage%3daHR0cHM6Ly9ldGphbnN0LnN0b2NraG9sbS5zZS92YXJkbmFkc2hhdmFyZS9pbmxvZ2dhZDIvaGVt&verifyorder=${order}&_=${Date.now()}`
 
 export const loginCookie =


### PR DESCRIPTION
When using bankId app on the same device the personal number is not required.
It is the same URL just omit the personal number parameter.

When redirecting to the bankId app on the device use the autostarttoken parameter to connect the api call with the bankId login - which we do in the app.