### PR TITLE
fix: 🐛 Fixa markdownkonvertering av hårresande html

### DIFF
--- a/lib/parse/__tests__/news.test.ts
+++ b/lib/parse/__tests__/news.test.ts
@@ -199,7 +199,7 @@ describe('newsItem', () => {
           BannerImageGuid: '7a8142d9d9d54cf090e8457e4c629227',
           BannerImageListId: 'a88c22e8-7094-4a71-b4fd-8792c62a7b4a',
           Body:
-            '<i>italic</i> <b>bold</b> <em>emphasis </em> <strong>strong</strong>',
+            '<i>italic</i>  <b>bold</b>  <em>emphasis </em><br/><strong>strong</strong>',
           BodyNoHtml: null,
           AuthorDisplayName: 'Tieto Evry',
           altText: null,

--- a/lib/parse/__tests__/news.test.ts
+++ b/lib/parse/__tests__/news.test.ts
@@ -173,3 +173,70 @@ describe('newsItem', () => {
     expect(item.body).toContain(' **tillfället** ')
   })
 })
+
+
+describe('newsItem', () => {
+  beforeEach(() => {
+    response = {
+      Success: true,
+      Error: null,
+      Data: {
+        CurrentNewsItem: {
+          NewsId: '123',
+          SiteId:
+            'elevstockholm.sharepoint.com,d112c398-71d4-468f-9a59-84d806751b08,3addab10-546a-4551-8076-72c9cd67f961',
+          NewsListId: '95df7d70-fbf0-470d-9926-e4e633f77f27',
+          NewsItemId:
+            'elevstockholm.sharepoint.com,d112c398-71d4-468f-9a59-84d806751b08,3addab10-546a-4551-8076-72c9cd67f961_40',
+          Header: 'Avlusningsdagarna 5-7 februari 2021',
+          PublicationDate: '/Date(1612445471000)/',
+          PubDateSE: '4 februari 2021 14:31',
+          ModifiedDate: '/Date(1612445852000)/',
+          ModDateSE: '14 februari 2021 14:37',
+          Source: 'Södra Ängby skola',
+          Preamble: 'Kära vårdnadshavare!I helgen är det avlusningsdagar!',
+          BannerImageUrl: '123123.jpeg',
+          BannerImageGuid: '7a8142d9d9d54cf090e8457e4c629227',
+          BannerImageListId: 'a88c22e8-7094-4a71-b4fd-8792c62a7b4a',
+          Body:
+            '<i>italic</i> <b>bold</b> <em>emphasis </em> <strong>strong</strong>',
+          BodyNoHtml: null,
+          AuthorDisplayName: 'Tieto Evry',
+          altText: null,
+          OriginalSourceUrl: null,
+        },
+        CurrentChild: null,
+        ViewGlobalTranslations: {},
+        ViewLocalTranslations: {},
+        Children: null,
+        Status: null,
+        GlobalTranslationIds: [
+          'InformationalHeader',
+          'ContactUsMessageLabel',
+          'Send',
+          'RequiredFieldMessageInfo',
+          'Sex',
+          'Male',
+          'Female',
+          'SSN',
+          'FirstName',
+          'LastName',
+          'Email',
+          'Zip',
+          'Address',
+          'ValidationRequiredFieldMessage',
+          'ValidationErrorMessage',
+        ],
+        LocalTranslationIds: ['IndexPageHeading1'],
+      },
+    }
+  })
+  it(' emphasizes correctly', () => {
+    const item = newsItemDetails(response)
+
+    expect(item.body).toContain('*italic*')
+    expect(item.body).toContain('**bold**')
+    expect(item.body).toContain('*emphasis*')
+    expect(item.body).toContain('**strong**')
+  })
+})

--- a/lib/parse/__tests__/news.test.ts
+++ b/lib/parse/__tests__/news.test.ts
@@ -117,7 +117,7 @@ describe('newsItem', () => {
           BannerImageGuid: '7a8142d9d9d54cf090e8457e4c629227',
           BannerImageListId: 'a88c22e8-7094-4a71-b4fd-8792c62a7b4a',
           Body:
-            '<div data-sp-rte=""><p><span><span><span>Kära vårdnadshavare!</span></span></span></p><p><span><span><span>I helgen är det avlusningsdagar! Ta tillfället i akt att luskamma ditt barn </span></span></span></p><p><span><span><span>Du finner all info du behöver på <a href="https&#58;//www.1177.se/sjukdomar--besvar/hud-har-och-naglar/harbotten-och-harsackar/huvudloss/" data-cke-saved-href="https&#58;//www.1177.se/sjukdomar--besvar/hud-har-och-naglar/harbotten-och-harsackar/huvudloss/" data-interception="on" title="https&#58;//www.1177.se/sjukdomar--besvar/hud-har-och-naglar/harbotten-och-harsackar/huvudloss/">1177 hemsida </a></span></span></span><span><span><span>​​​​​​​</span></span></span></p><p><span><span><span>Trevlig helg!</span></span></span></p><p><span><span><span>​​​​​​​</span></span></span></p></div>',
+            '<div data-sp-rte=""><p><span><span><span>Kära vårdnadshavare!</span></span></span></p><p><span><span><span>I helgen är det avlusningsdagar! Ta <strong>tillfället </strong>i akt att luskamma ditt barn </span></span></span></p><p><span><span><span>Du finner all info du behöver på <a href="https&#58;//www.1177.se/sjukdomar--besvar/hud-har-och-naglar/harbotten-och-harsackar/huvudloss/" data-cke-saved-href="https&#58;//www.1177.se/sjukdomar--besvar/hud-har-och-naglar/harbotten-och-harsackar/huvudloss/" data-interception="on" title="https&#58;//www.1177.se/sjukdomar--besvar/hud-har-och-naglar/harbotten-och-harsackar/huvudloss/">1177 hemsida </a></span></span></span><span><span><span>​​​​​​​</span></span></span></p><p><span><span><span>Trevlig helg!</span></span></span></p><p><span><span><span>​​​​​​​</span></span></span></p></div>',
           BodyNoHtml: null,
           AuthorDisplayName: 'Tieto Evry',
           altText: null,
@@ -170,5 +170,6 @@ describe('newsItem', () => {
     const expected =
       '[1177 hemsida](https://www.1177.se/sjukdomar--besvar/hud-har-och-naglar/harbotten-och-harsackar/huvudloss/)​​​​​​​'
     expect(item.body).toContain(expected)
+    expect(item.body).toContain(' **tillfället** ')
   })
 })

--- a/lib/parseHtml.test.ts
+++ b/lib/parseHtml.test.ts
@@ -99,25 +99,25 @@ Kolla in Reddit: [https://reddit.com/water-balloons/where-to-buy/](https://reddi
 
 [https://wnews.ycombinator.com/](https://wnews.ycombinator.com/)
 
-Vi fortsätter också att:
+Vi fortsätter också att: 
 
-- hålla avstånd.
+- hålla avstånd. 
 - ha flera digitala möten.
-- tvätta händerna.
-- undvika kollektivtrafik om det är möjligt.
+- tvätta händerna. 
+- undvika kollektivtrafik om det är möjligt. 
 
 - stanna hemma även när man bara känner sig lite sjuk.
 - vädra ofta
 
 Ta hand om er!
 
-**Ha kul tillsammans, på avstånd.**
+**Ha kul tillsammans, på avstånd.**  
 
-Stort tack för ert samarbete! ${nbsp}
+Stort tack för ert samarbete!  
 
 Vänligen, 
 
-rektorfnamn rektorenamn, rektor${nbsp} 
+rektorfnamn rektorenamn, rektor  
 
 **Vid frågor, kontakta oss gärna:**
 

--- a/lib/parseHtml.test.ts
+++ b/lib/parseHtml.test.ts
@@ -87,7 +87,7 @@ Nu är det dags för vattenballongkrig  12/2-21 till om med tisdag 16/2-21.
 
 Alla knep är tillåtna. 
 
-Det blir kul.
+**Det blir kul.**
 
 Kolla in Reddit: [https://reddit.com/water-balloons/where-to-buy/](https://reddit.com/water-balloons/where-to-buy/)
 
@@ -111,7 +111,7 @@ Vi fortsätter också att:
 
 Ta hand om er!
 
-Ha kul tillsammans, på avstånd.
+**Ha kul tillsammans, på avstånd.**
 
 Stort tack för ert samarbete! ${nbsp}
 
@@ -119,9 +119,9 @@ Vänligen,
 
 rektorfnamn rektorenamn, rektor${nbsp} 
 
-Vid frågor, kontakta oss gärna:
+**Vid frågor, kontakta oss gärna:**
 
-Skolledning
+**Skolledning**
 
 rektorfnamn rektorenamn rektor: [rektorfnamn.rektorenamn@edu.stockholm.se](mailto:rektorfnamn.rektorenamn@edu.stockholm.se)
 
@@ -129,7 +129,7 @@ brektorfnamn brektorenamn, bitr. rektor: [brektorfnamn.u.brektorenamn@edu.stockh
 
 b2rektorfnamn b2rektorenamn bitr. rektor: [b2rektorfnamn.b2rektorenamn@edu.stockholm.se](mailto:b2rektorfnamn.b2rektorenamn@edu.stockholm.se)
 
-Skolhälsan
+**Skolhälsan**
 
 b2rektorfnamn skolskstenamn skolsköterska: [b2rektorfnamn.skolskstenamn@edu.stockholm.se](mailto:b2rektorfnamn.skolskstenamn@edu.stockholm.se)
 

--- a/lib/parseHtml.ts
+++ b/lib/parseHtml.ts
@@ -52,6 +52,7 @@ interface Node {
 const converter = 'MarkdownExtra'
 const overides = {
   a: (node: Node) => `[${node.md}](${node.attrs.href})`,
+  img: (node: Node) => `![${node.attrs.title}](${node.attrs.src})`,
 }
 
 export const toMarkdown = (html: string): string => {

--- a/lib/parseHtml.ts
+++ b/lib/parseHtml.ts
@@ -40,6 +40,15 @@ const deepClean = (node: HTMLElement): HTMLElement => {
   return cleaned
 }
 
+const rearrangeWhitespace = (html: string = ''): string => {
+  let content = html
+  trimNodes.forEach((trimNode) => {
+    content = content.replace(`<${trimNode}> `, ` <${trimNode}>`)
+    content = content.replace(` </${trimNode}>`, `</${trimNode}> `)
+  })
+  return content
+}
+
 export const clean = (html: string = ''): string =>
   deepClean(parse(decode(html))).outerHTML
 
@@ -56,7 +65,8 @@ const overides = {
 }
 
 export const toMarkdown = (html: string): string => {
-  const trimmed = clean(html)
+  const rearranged = rearrangeWhitespace(html)
+  const trimmed = clean(rearranged)
   const markdown = h2m(trimmed, { overides, converter })
   const decoded = htmlDecode(markdown)
   return decoded

--- a/lib/parseHtml.ts
+++ b/lib/parseHtml.ts
@@ -41,10 +41,10 @@ const deepClean = (node: HTMLElement): HTMLElement => {
 }
 
 const rearrangeWhitespace = (html: string = ''): string => {
-  let content = html
+  let content = html.split('&#160;').join('&amp;nbsp;')
   trimNodes.forEach((trimNode) => {
-    content = content.replace(`<${trimNode}> `, ` <${trimNode}>`)
-    content = content.replace(` </${trimNode}>`, `</${trimNode}> `)
+    content = content.split(`<${trimNode}> `).join(` <${trimNode}>`)
+    content = content.split(` </${trimNode}>`).join(`</${trimNode}> `)
   })
   return content
 }
@@ -61,7 +61,7 @@ interface Node {
 const converter = 'MarkdownExtra'
 const overides = {
   a: (node: Node) => `[${node.md}](${node.attrs.href})`,
-  img: (node: Node) => `![${node.attrs.title}](${node.attrs.src})`,
+  img: (node: Node) => `![${node.attrs.title || ''}](${node.attrs.src})`,
   i: (node: Node) => `*${node.md}*`,
   b: (node: Node) => `**${node.md}**`,
 }

--- a/lib/parseHtml.ts
+++ b/lib/parseHtml.ts
@@ -62,6 +62,8 @@ const converter = 'MarkdownExtra'
 const overides = {
   a: (node: Node) => `[${node.md}](${node.attrs.href})`,
   img: (node: Node) => `![${node.attrs.title}](${node.attrs.src})`,
+  i: (node: Node) => `*${node.md}*`,
+  b: (node: Node) => `**${node.md}**`,
 }
 
 export const toMarkdown = (html: string): string => {


### PR DESCRIPTION
Attribut i vissa bild-taggar i nyhetsbreven verkar förvirra markdown-konverteraren. Lade till en override. https://github.com/kolplattformen/skolplattformen/issues/261

Vissa felaktigt borttagna mellanslag är tillbaka (men inte alla ännu)
Viss saknad formatering är också tillbaka
https://github.com/kolplattformen/skolplattformen/issues/160